### PR TITLE
Firma-bugfix_notifications: removed unneeded condition in AppDelegate

### DIFF
--- a/src/main/AppDelegate.m
+++ b/src/main/AppDelegate.m
@@ -128,9 +128,7 @@ void uncaughtExceptionHandler(NSException *exception)
         [[PushNotificationService instance] resetNotificationRequired];
     }*/
     
-    if ([LoginService instance].serverSupportLogin) {
-       [[PushNotificationService instance] updateTokenOfPushNotificationsService: [tokenHex uppercaseString]];
-    }
+    [[PushNotificationService instance] updateTokenOfPushNotificationsService: [tokenHex uppercaseString]];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(nonnull NSError *)error {


### PR DESCRIPTION
Removed unneeded condition in `AppDelegate` to allow notifications for remote certifications login.