### PR TITLE
Firma-bugfix_sign_list: session id value set to nil when login with c…

### DIFF
--- a/src/Services/LoginService.m
+++ b/src/Services/LoginService.m
@@ -119,6 +119,7 @@ static NSString *const kSessionId = @"sessionId";
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[SVProgressHUD show];
 	});
+    _sessionId = nil;
     [self resetUserValues];
 	[self extracted:failure success:success];
 }
@@ -130,6 +131,7 @@ static NSString *const kSessionId = @"sessionId";
 
 	LoginNetwork *loginNetwork = [LoginNetwork new];
     [self resetUserValues];
+    _sessionId = nil;
 
 	[loginNetwork logout:^{
 		dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Bug description: after a login with a remote certificate, if the user logout and login with a normal certificate, the elements of the pending tab are the same as with the remote certificate.

The problem is that with the remote certificate, the server requests include an `ssid` that is not set to nil after a logout and it's being used in the next request with the normal certificate.